### PR TITLE
Add benchmark and lint fixes

### DIFF
--- a/docs/tygent-benchmark.md
+++ b/docs/tygent-benchmark.md
@@ -1,0 +1,29 @@
+# Tygent Benchmark
+
+This document explains how the Tygent integration is tested for performance.
+
+The benchmark compares the default sequential execution with the optional
+Tygent scheduler that executes tools in parallel.
+
+## Prerequisites
+
+- Node.js 18 or later
+- A valid `GEMINI_API_KEY`
+
+## Steps
+
+1. **Install dependencies**
+   ```bash
+   npm ci
+   ```
+2. **Build the packages**
+   ```bash
+   npm run build
+   ```
+3. **Run the benchmark**
+   ```bash
+   node --loader ts-node/esm benchmark/tygent-benchmark.ts
+   ```
+
+The script will run a set of sample prompts twice – once with Tygent disabled and
+once with Tygent enabled – printing the latency and token usage for each.

--- a/docs/tygent-integration.md
+++ b/docs/tygent-integration.md
@@ -55,3 +55,16 @@ echo "Generate README" | gemini --tygent
 
 When enabled, tool calls requested by Gemini are executed in parallel
 using the optimized DAG.
+
+## Benchmark
+
+A simple benchmark script is provided to compare latency and token
+consumption with and without Tygent. Build the packages first and then
+run the script using `ts-node`:
+
+```bash
+npm run build
+node --loader ts-node/esm benchmark/tygent-benchmark.ts
+```
+
+Ensure the `GEMINI_API_KEY` environment variable is set before running.

--- a/docs/tygent-integration.md
+++ b/docs/tygent-integration.md
@@ -68,3 +68,6 @@ node --loader ts-node/esm benchmark/tygent-benchmark.ts
 ```
 
 Ensure the `GEMINI_API_KEY` environment variable is set before running.
+
+See [tygent-benchmark.md](./tygent-benchmark.md) for more details on running
+the benchmark.

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -208,7 +208,7 @@ export function useReactToolScheduler(
   );
 
   const tygentSchedule = useCallback(
-    async (requests: ToolCallRequestInfo[], signal: AbortSignal) => {
+    async (requests: ToolCallRequestInfo[], _signal: AbortSignal) => {
       const registry = await config.getToolRegistry();
       const client = config.getGeminiClient();
       const tygent = new TygentScheduler(client, registry);

--- a/packages/core/src/tygent/tygentScheduler.ts
+++ b/packages/core/src/tygent/tygentScheduler.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { DAG, LLMNode, ToolNode, Scheduler } from 'tygent';
 import { GeminiClient } from '../core/client.js';
 import { ToolRegistry, ToolCallRequestInfo, ToolResult } from '../index.js';

--- a/packages/core/src/tygent/workflowExecutor.ts
+++ b/packages/core/src/tygent/workflowExecutor.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { GeminiClient } from '../core/client.js';
 import { ToolRegistry, ToolCallRequestInfo } from '../index.js';
 import { TygentScheduler } from './tygentScheduler.js';
@@ -17,7 +23,7 @@ export async function runPromptWithTools(
   client: GeminiClient,
   registry: ToolRegistry,
   prompt: string,
-  signal: AbortSignal = new AbortController().signal,
+  _signal: AbortSignal = new AbortController().signal,
 ): Promise<string> {
   const scheduler = new TygentScheduler(client, registry);
   const llmNode = scheduler.addLLMCall(prompt);


### PR DESCRIPTION
## Summary
- add missing license headers for Tygent files
- update scheduler to ignore unused signal param
- improve benchmark script and use built packages
- document how to run the benchmark

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687020d2760c832b918d332ce55c3419