### PR TITLE
Enable Gemini without API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You are now ready to use the Gemini CLI!
 
 ### For advanced use or increased limits:
 
-If you need to use a specific model or require a higher request capacity, you can use an API key:
+If you need higher limits or want to target a specific model, you can provide an optional API key:
 
 1. Generate a key from [Google AI Studio](https://aistudio.google.com/apikey).
 2. Set it as an environment variable in your terminal. Replace `YOUR_API_KEY` with your generated key.

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -26,9 +26,9 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
       source ~/.bashrc
       ```
 
-2.  **<a id="gemini-api-key"></a>Gemini API key:**
-    - Obtain your API key from Google AI Studio: [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
-    - Set the `GEMINI_API_KEY` environment variable. In the following methods, replace `YOUR_GEMINI_API_KEY` with the API key you obtained from Google AI Studio:
+2.  **<a id="gemini-api-key"></a>Gemini API key (optional):**
+    - Obtain a key from Google AI Studio if you need higher usage limits: [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
+    - Set the `GEMINI_API_KEY` environment variable. In the following methods, replace `YOUR_GEMINI_API_KEY` with the API key you obtained:
       - You can temporarily set the environment variable in your current shell session using the following command:
         ```bash
         export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
@@ -105,6 +105,6 @@ echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .gemini/.env
 mkdir -p ~/.gemini
 cat >> ~/.gemini/.env <<'EOF'
 GOOGLE_CLOUD_PROJECT="your-project-id"
-GEMINI_API_KEY="your-gemini-api-key"
+GEMINI_API_KEY="your-gemini-api-key" # optional
 EOF
 ```

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -231,9 +231,8 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 2.  If not found, it searches upwards in parent directories until it finds an `.env` file or reaches the project root (identified by a `.git` folder) or the home directory.
 3.  If still not found, it looks for `~/.env` (in the user's home directory).
 
-- **`GEMINI_API_KEY`** (Required):
-  - Your API key for the Gemini API.
-  - **Crucial for operation.** The CLI will not function without it.
+- **`GEMINI_API_KEY`** (Optional):
+  - API key for the Gemini API. Provide it to unlock higher limits or paid features.
   - Set this in your shell profile (e.g., `~/.bashrc`, `~/.zshrc`) or an `.env` file.
 - **`GEMINI_MODEL`**:
   - Specifies the default Gemini model to use.

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -25,7 +25,7 @@ While the `packages/cli` portion of Gemini CLI provides the user interface, `pac
 
 The core plays a vital role in security:
 
-- **API key management:** It handles the `GEMINI_API_KEY` and ensures it's used securely when communicating with the Gemini API.
+- **API key management:** When provided, the `GEMINI_API_KEY` is used securely when communicating with the Gemini API.
 - **Tool execution:** When tools interact with the local system (e.g., `run_shell_command`), the core (and its underlying tool implementations) must do so with appropriate caution, often involving sandboxing mechanisms to prevent unintended modifications.
 
 ## Chat history compression

--- a/docs/tygent-benchmark.md
+++ b/docs/tygent-benchmark.md
@@ -8,7 +8,7 @@ Tygent scheduler that executes tools in parallel.
 ## Prerequisites
 
 - Node.js 18 or later
-- A valid `GEMINI_API_KEY`
+- (Optional) `GEMINI_API_KEY` for higher request limits
 
 ## Steps
 

--- a/docs/tygent-integration.md
+++ b/docs/tygent-integration.md
@@ -67,7 +67,7 @@ npm run build
 node --loader ts-node/esm benchmark/tygent-benchmark.ts
 ```
 
-Ensure the `GEMINI_API_KEY` environment variable is set before running.
+If you have a `GEMINI_API_KEY`, export it before running for higher limits.
 
 See [tygent-benchmark.md](./tygent-benchmark.md) for more details on running
 the benchmark.

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -14,9 +14,6 @@ export const validateAuthMethod = (authMethod: string): string | null => {
   }
 
   if (authMethod === AuthType.USE_GEMINI) {
-    if (!process.env.GEMINI_API_KEY) {
-      return 'GEMINI_API_KEY environment variable not found. Add that to your .env and try again, no reload needed!';
-    }
     return null;
   }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -274,17 +274,10 @@ async function validateNonInterActiveAuth(
   selectedAuthType: AuthType | undefined,
   nonInteractiveConfig: Config,
 ) {
-  // making a special case for the cli. many headless environments might not have a settings.json set
-  // so if GEMINI_API_KEY is set, we'll use that. However since the oauth things are interactive anyway, we'll
-  // still expect that exists
-  if (!selectedAuthType && !process.env.GEMINI_API_KEY) {
-    console.error(
-      'Please set an Auth method in your .gemini/settings.json OR specify GEMINI_API_KEY env variable file before running',
-    );
-    process.exit(1);
+  // default to Gemini API key auth when no auth method is specified
+  if (!selectedAuthType) {
+    selectedAuthType = AuthType.USE_GEMINI;
   }
-
-  selectedAuthType = selectedAuthType || AuthType.USE_GEMINI;
   const err = validateAuthMethod(selectedAuthType);
   if (err != null) {
     console.error(err);

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -32,13 +32,11 @@ describe('AuthDialog', () => {
       <AuthDialog
         onSelect={() => {}}
         settings={settings}
-        initialErrorMessage="GEMINI_API_KEY  environment variable not found"
+        initialErrorMessage="Invalid auth method"
       />,
     );
 
-    expect(lastFrame()).toContain(
-      'GEMINI_API_KEY  environment variable not found',
-    );
+    expect(lastFrame()).toContain('Invalid auth method');
   });
 
   it('should prevent exiting when no auth method is selected and show error message', async () => {


### PR DESCRIPTION
## Summary
- allow USE_GEMINI auth without GEMINI_API_KEY
- default to `USE_GEMINI` when no auth type is set
- adjust docs to make GEMINI_API_KEY optional
- update benchmark docs
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a40c54c0832bbfa6f9b6c17146d9