### PR TITLE
Fix benchmark auth instructions

### DIFF
--- a/docs/tygent-benchmark.md
+++ b/docs/tygent-benchmark.md
@@ -8,7 +8,17 @@ Tygent scheduler that executes tools in parallel.
 ## Prerequisites
 
 - Node.js 18 or later
-- (Optional) `GEMINI_API_KEY` for higher request limits
+- Authentication configured. You can either log in with your Google account or
+   provide a `GEMINI_API_KEY`:
+   - **Login with Google:** run `gemini` and follow the browser prompt. The
+     credentials are cached locally for reuse.
+   - **API key:** generate one from
+     [Google AI Studio](https://aistudio.google.com/app/apikey) and export it
+     before running the benchmark:
+
+     ```bash
+     export GEMINI_API_KEY="YOUR_API_KEY"
+     ```
 
 ## Steps
 
@@ -24,6 +34,10 @@ Tygent scheduler that executes tools in parallel.
    ```bash
    node --loader ts-node/esm benchmark/tygent-benchmark.ts
    ```
+
+If the script fails with an error such as `Could not load the default
+credentials`, it means no credentials were found. Either log in with Google or
+export a `GEMINI_API_KEY` before running.
 
 The script will run a set of sample prompts twice – once with Tygent disabled and
 once with Tygent enabled – printing the latency and token usage for each.

--- a/docs/tygent-integration.md
+++ b/docs/tygent-integration.md
@@ -67,7 +67,14 @@ npm run build
 node --loader ts-node/esm benchmark/tygent-benchmark.ts
 ```
 
-If you have a `GEMINI_API_KEY`, export it before running for higher limits.
+Ensure you are authenticated before running the benchmark. You can either log in
+with your Google account or provide a `GEMINI_API_KEY`. To use an API key,
+generate one from [Google AI Studio](https://aistudio.google.com/app/apikey) and
+export it:
+
+```bash
+export GEMINI_API_KEY="YOUR_API_KEY"
+```
 
 See [tygent-benchmark.md](./tygent-benchmark.md) for more details on running
 the benchmark.


### PR DESCRIPTION
## Summary
- document tygent benchmark authentication options
- mention Google login as an alternative

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878156c7c60832b932e5217d64366c1