### PR TITLE
Fix benchmark client config access

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -72,6 +72,13 @@ export class GeminiClient {
     this.chat = await this.startChat();
   }
 
+  /**
+   * Returns the configuration used to initialize this client.
+   */
+  getConfig(): Config {
+    return this.config;
+  }
+
   getContentGenerator(): ContentGenerator {
     if (!this.contentGenerator) {
       throw new Error('Content generator not initialized');


### PR DESCRIPTION
## TLDR
- expose config from `GeminiClient`

## Dive Deeper
- the benchmark script expects `GeminiClient.getConfig()` when executing tool calls
- add a simple getter to return the original `Config`

## Reviewer Test Plan
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687955c87ca8832ba7cbb3f92c961f7f