### PR TITLE
Fix duplicate LLM call in tygent workflow

### DIFF
--- a/packages/core/src/tygent/workflowExecutor.test.ts
+++ b/packages/core/src/tygent/workflowExecutor.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runPromptWithTools } from './workflowExecutor.js';
+import type { GeminiClient } from '../core/client.js';
+import type { ToolRegistry } from '../index.js';
+import type { GenerateContentResponse } from '@google/genai';
+
+const mockResponse: GenerateContentResponse = {
+  candidates: [
+    {
+      content: { parts: [{ text: 'hello' }], role: 'model' },
+      finishReason: 'STOP',
+      index: 0,
+      safetyRatings: [],
+    },
+  ],
+  promptFeedback: { safetyRatings: [] },
+};
+
+describe('runPromptWithTools', () => {
+  it('performs only one LLM call when no tools are requested', async () => {
+    const generateContent = vi.fn().mockResolvedValue(mockResponse);
+    const client = { generateContent } as unknown as GeminiClient;
+    const registry = {} as ToolRegistry;
+
+    const result = await runPromptWithTools(client, registry, 'hello');
+
+    expect(result).toBe('hello');
+    expect(generateContent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/tygent/workflowExecutor.ts
+++ b/packages/core/src/tygent/workflowExecutor.ts
@@ -25,14 +25,21 @@ export async function runPromptWithTools(
   prompt: string,
   _signal: AbortSignal = new AbortController().signal,
 ): Promise<string> {
+  // First run the LLM call directly to discover tool invocations.
+  const initialResp = await client.generateContent(
+    [{ role: 'user', parts: [{ text: prompt }] }],
+    {},
+    _signal,
+  );
+
+  const functionCalls: FunctionCall[] = getFunctionCalls(initialResp) ?? [];
+  // If no tools are required, return the initial response text immediately.
+  if (functionCalls.length === 0) {
+    return getResponseText(initialResp) ?? String(initialResp);
+  }
+
+  // Build a scheduler for the tool executions and follow up LLM call.
   const scheduler = new TygentScheduler(client, registry);
-  const llmNode = scheduler.addLLMCall(prompt);
-
-  // Run the initial LLM call to discover required tool invocations.
-  const firstResults = (await scheduler.run())[llmNode] as GenerateContentResponse;
-  const functionCalls: FunctionCall[] =
-    getFunctionCalls(firstResults) ?? [];
-
   const toolNodeNames: string[] = [];
   for (const fc of functionCalls) {
     const request: ToolCallRequestInfo = {
@@ -41,15 +48,11 @@ export async function runPromptWithTools(
       args: (fc.args ?? {}) as Record<string, unknown>,
       isClientInitiated: false,
     };
-    const nodeName = scheduler.addToolCall(request, [llmNode]);
+    const nodeName = scheduler.addToolCall(request);
     toolNodeNames.push(nodeName);
   }
 
-  let finalNode = llmNode;
-  if (toolNodeNames.length) {
-    // Add a follow up LLM call that depends on all tools finishing.
-    finalNode = scheduler.addLLMCall('continue', toolNodeNames);
-  }
+  const finalNode = scheduler.addLLMCall('continue', toolNodeNames);
 
   const results = await scheduler.run();
   const finalResp = results[finalNode] as GenerateContentResponse;


### PR DESCRIPTION
## Summary
- avoid re-running the first LLM call in `runPromptWithTools`
- add a unit test covering the single-call case when no tools are needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687971785608832bbb4c4d37507f7173